### PR TITLE
Respect line width when create bar item to prevent clipping

### DIFF
--- a/Class/CBStoreHouseRefreshControl.m
+++ b/Class/CBStoreHouseRefreshControl.m
@@ -97,10 +97,11 @@ NSString *const yKey = @"y";
         CGPoint startPoint = CGPointFromString(startPoints[i]);
         CGPoint endPoint = CGPointFromString(endPoints[i]);
         
-        if (startPoint.x > width) width = startPoint.x;
-        if (endPoint.x > width) width = endPoint.x;
-        if (startPoint.y > height) height = startPoint.y;
-        if (endPoint.y > height) height = endPoint.y;
+        // shift it base on line width
+        if (startPoint.x + lineWidth > width) width = startPoint.x + lineWidth;
+        if (endPoint.x + lineWidth > width) width = endPoint.x + lineWidth;
+        if (startPoint.y + lineWidth > height) height = startPoint.y + lineWidth;
+        if (endPoint.y + lineWidth > height) height = endPoint.y + lineWidth;
     }
     refreshControl.frame = CGRectMake(0, 0, width, height);
 
@@ -110,6 +111,9 @@ NSString *const yKey = @"y";
         
         CGPoint startPoint = CGPointFromString(startPoints[i]);
         CGPoint endPoint = CGPointFromString(endPoints[i]);
+        // shift it base on line width
+        startPoint = CGPointMake(startPoint.x + lineWidth/2, startPoint.y + lineWidth/2);
+        endPoint = CGPointMake(endPoint.x + lineWidth/2, endPoint.y + lineWidth/2);
 
         BarItem *barItem = [[BarItem alloc] initWithFrame:refreshControl.frame startPoint:startPoint endPoint:endPoint color:color lineWidth:lineWidth];
         barItem.tag = i;


### PR DESCRIPTION
currently when you set the line width to a big number, it will draw the line off screen. To fix it, shift the startPoint and endPoint by half the line width, and make the frame of refresh control bigger, to hold the whole bar item
