### PR TITLE
Added ActivityIndicatorView and fixed bug that breaks contentInsets

### DIFF
--- a/CBStoreHouseRefreshControl.xcodeproj/project.pbxproj
+++ b/CBStoreHouseRefreshControl.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0BFB9BAA1A084144008C790A /* CBStoreHouseRefreshControl.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BFB9BA91A084144008C790A /* CBStoreHouseRefreshControl.m */; };
+		38C679AD1A948C9F00AE1465 /* CBStoreHouseActivityIndicatorView.m in Sources */ = {isa = PBXBuildFile; fileRef = 38C679AC1A948C9F00AE1465 /* CBStoreHouseActivityIndicatorView.m */; };
 		FF6F542D1A086CC200BE5C52 /* storehouse.plist in Resources */ = {isa = PBXBuildFile; fileRef = FF6F542C1A086CC200BE5C52 /* storehouse.plist */; };
 		FFB290C919FCC1320058F2BF /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = FFB290C819FCC1320058F2BF /* main.m */; };
 		FFB290CC19FCC1320058F2BF /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = FFB290CB19FCC1320058F2BF /* AppDelegate.m */; };
@@ -31,6 +32,8 @@
 
 /* Begin PBXFileReference section */
 		0BFB9BA91A084144008C790A /* CBStoreHouseRefreshControl.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CBStoreHouseRefreshControl.m; path = Class/CBStoreHouseRefreshControl.m; sourceTree = "<group>"; };
+		38C679AB1A948C9F00AE1465 /* CBStoreHouseActivityIndicatorView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CBStoreHouseActivityIndicatorView.h; path = Class/CBStoreHouseActivityIndicatorView.h; sourceTree = "<group>"; };
+		38C679AC1A948C9F00AE1465 /* CBStoreHouseActivityIndicatorView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CBStoreHouseActivityIndicatorView.m; path = Class/CBStoreHouseActivityIndicatorView.m; sourceTree = "<group>"; };
 		FF6F542C1A086CC200BE5C52 /* storehouse.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = storehouse.plist; sourceTree = "<group>"; };
 		FFB290C319FCC1320058F2BF /* CBStoreHouseRefreshControl.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CBStoreHouseRefreshControl.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FFB290C719FCC1320058F2BF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -137,6 +140,8 @@
 				FFFB8C951A02044C0007988E /* BarItem.m */,
 				FFFB8C981A02F7DC0007988E /* CBStoreHouseRefreshControl.h */,
 				0BFB9BA91A084144008C790A /* CBStoreHouseRefreshControl.m */,
+				38C679AB1A948C9F00AE1465 /* CBStoreHouseActivityIndicatorView.h */,
+				38C679AC1A948C9F00AE1465 /* CBStoreHouseActivityIndicatorView.m */,
 			);
 			name = Class;
 			sourceTree = "<group>";
@@ -247,6 +252,7 @@
 				FFB290CC19FCC1320058F2BF /* AppDelegate.m in Sources */,
 				0BFB9BAA1A084144008C790A /* CBStoreHouseRefreshControl.m in Sources */,
 				FFB290C919FCC1320058F2BF /* main.m in Sources */,
+				38C679AD1A948C9F00AE1465 /* CBStoreHouseActivityIndicatorView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -360,6 +366,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+				);
 				INFOPLIST_FILE = CBStoreHouseRefreshControl/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -371,6 +381,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+				);
 				INFOPLIST_FILE = CBStoreHouseRefreshControl/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/CBStoreHouseRefreshControl/ContentViewController.m
+++ b/CBStoreHouseRefreshControl/ContentViewController.m
@@ -8,8 +8,11 @@
 
 #import "ContentViewController.h"
 #import "CBStoreHouseRefreshControl.h"
+#import "CBStoreHouseActivityIndicatorView.h"
 
 @interface ContentViewController ()
+
+@property (nonatomic, weak) CBStoreHouseActivityIndicatorView* activityView;
 
 @end
 
@@ -35,21 +38,43 @@
     self.tableView.tableFooterView = footer;
     
     // Let the show begins
-    self.storeHouseRefreshControl = [CBStoreHouseRefreshControl attachToScrollView:self.tableView target:self refreshAction:@selector(refreshTriggered:) plist:@"storehouse" color:[UIColor whiteColor] lineWidth:1.5 dropHeight:80 scale:1 horizontalRandomness:150 reverseLoadingAnimation:YES internalAnimationFactor:0.5];
+    self.storeHouseRefreshControl = [CBStoreHouseRefreshControl attachToScrollView:self.tableView target:self refreshAction:@selector(refreshTriggered:) plist:@"AKTA" color:[UIColor whiteColor] lineWidth:1.5 dropHeight:80 scale:1 horizontalRandomness:150 reverseLoadingAnimation:YES internalAnimationFactor:0.5];
     
     //self.storeHouseRefreshControl = [CBStoreHouseRefreshControl attachToScrollView:self.tableView target:self refreshAction:@selector(refreshTriggered:) plist:@"AKTA" color:[UIColor whiteColor] lineWidth:2 dropHeight:80 scale:0.7 horizontalRandomness:300 reverseLoadingAnimation:NO internalAnimationFactor:0.7];
-}
+    
+    }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"cell" forIndexPath:indexPath];
-
-    UIImageView *image = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"cell"]];
-    image.translatesAutoresizingMaskIntoConstraints = NO;
-    [cell.contentView addSubview:image];
     
-    [cell.contentView addConstraint:[NSLayoutConstraint constraintWithItem:image attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual toItem:cell.contentView attribute:NSLayoutAttributeCenterX multiplier:1 constant:0]];
-    [cell.contentView addConstraint:[NSLayoutConstraint constraintWithItem:image attribute:NSLayoutAttributeCenterY relatedBy:NSLayoutRelationEqual toItem:cell.contentView attribute:NSLayoutAttributeCenterY multiplier:1 constant:0]];
+    if (indexPath.row == 1)
+    {
+        UIImageView *image = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"cell"]];
+        image.translatesAutoresizingMaskIntoConstraints = NO;
+        [cell.contentView addSubview:image];
+        
+        [cell.contentView addConstraint:[NSLayoutConstraint constraintWithItem:image attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual toItem:cell.contentView attribute:NSLayoutAttributeCenterX multiplier:1 constant:0]];
+        [cell.contentView addConstraint:[NSLayoutConstraint constraintWithItem:image attribute:NSLayoutAttributeCenterY relatedBy:NSLayoutRelationEqual toItem:cell.contentView attribute:NSLayoutAttributeCenterY multiplier:1 constant:0]];
+    }
+    else
+    {
+        CBStoreHouseActivityIndicatorView *activityIndicator = [[CBStoreHouseActivityIndicatorView alloc] initWithPlist:@"AKTA"];
+        
+        CGRect frame = activityIndicator.frame;
+        frame.origin.y = 100.0;
+        activityIndicator.frame = frame;
+        
+        [cell.contentView addSubview:activityIndicator];
+        
+        activityIndicator.hasLoadingAnimation = YES;
+        activityIndicator.animating = YES;
+        
+        self.activityView = activityIndicator;
+        
+        [self performSelector:@selector(stopActivity) withObject:nil afterDelay:5.0];
+
+    }
 
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
     cell.backgroundColor = [UIColor clearColor];
@@ -57,9 +82,14 @@
     return cell;
 }
 
+- (void)stopActivity
+{
+    self.activityView.animating = NO;
+}
+
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
 {
-    return 1;
+    return 2;
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath

--- a/Class/CBStoreHouseActivityIndicatorView.h
+++ b/Class/CBStoreHouseActivityIndicatorView.h
@@ -53,4 +53,6 @@
 
 - (void)setStartPoints:(NSArray *)startPoints endPoints:(NSArray *)endPoints;
 
+- (void)setPointsWithPlist:(NSString *)plist;
+
 @end

--- a/Class/CBStoreHouseActivityIndicatorView.h
+++ b/Class/CBStoreHouseActivityIndicatorView.h
@@ -1,0 +1,54 @@
+//
+//  CBStoreHouseActivityIndicatorView.h
+//  CBStoreHouseRefreshControl
+//
+//  Created by Dal Rupnik on 18/02/15.
+//  Copyright (c) 2015 Suyu Zhang. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface CBStoreHouseActivityIndicatorView : UIView
+
+/*!
+ *  Color of the shape provided on constructor
+ */
+@property (nonatomic, strong) UIColor* color;
+
+@property (nonatomic, assign) CGFloat lineWidth;
+@property (nonatomic, assign) CGFloat scale;
+
+@property (nonatomic, assign) CGFloat animationHeight;
+@property (nonatomic, assign) CGFloat horizontalRandomness;
+
+@property (nonatomic, assign) BOOL reverseLoadingAnimation;
+
+/*!
+ *  Loading animation will first construct the item and deconstuct
+ */
+@property (nonatomic, assign) BOOL hasLoadingAnimation;
+@property (nonatomic, assign) NSTimeInterval loadingAnimationDuration;
+
+@property (nonatomic, assign, getter = isAnimating) BOOL animating;
+
+/*!
+ *  Loads points from Plist
+ *
+ *  @param frame to display
+ *  @param plist to render
+ *
+ *  @return instance of view
+ */
+- (instancetype)initWithPlist:(NSString *)plist;
+
+/*!
+ *  Designated initializer: Shape of made from CGPoint structs
+ *
+ *  @param startPoints array of points
+ *  @param endPoints array of points
+ *
+ *  @return instance
+ */
+- (instancetype)initWithStartPoints:(NSArray *)startPoints endPoints:(NSArray *)endPoints;
+
+@end

--- a/Class/CBStoreHouseActivityIndicatorView.h
+++ b/Class/CBStoreHouseActivityIndicatorView.h
@@ -28,7 +28,10 @@
  *  Loading animation will first construct the item and deconstuct
  */
 @property (nonatomic, assign) BOOL hasLoadingAnimation;
+
 @property (nonatomic, assign) NSTimeInterval loadingAnimationDuration;
+@property (nonatomic, assign) NSTimeInterval indeterminateAnimationTiming;
+@property (nonatomic, assign) NSTimeInterval indeterminateAnimationOffset;
 
 @property (nonatomic, assign, getter = isAnimating) BOOL animating;
 

--- a/Class/CBStoreHouseActivityIndicatorView.h
+++ b/Class/CBStoreHouseActivityIndicatorView.h
@@ -17,6 +17,7 @@
 
 @property (nonatomic, assign) CGFloat lineWidth;
 @property (nonatomic, assign) CGFloat scale;
+@property (nonatomic, assign) CGFloat pointScale;
 
 @property (nonatomic, assign) CGFloat animationHeight;
 @property (nonatomic, assign) CGFloat horizontalRandomness;

--- a/Class/CBStoreHouseActivityIndicatorView.h
+++ b/Class/CBStoreHouseActivityIndicatorView.h
@@ -51,4 +51,6 @@
  */
 - (instancetype)initWithStartPoints:(NSArray *)startPoints endPoints:(NSArray *)endPoints;
 
+- (void)setStartPoints:(NSArray *)startPoints endPoints:(NSArray *)endPoints;
+
 @end

--- a/Class/CBStoreHouseActivityIndicatorView.m
+++ b/Class/CBStoreHouseActivityIndicatorView.m
@@ -92,6 +92,7 @@
     self.reverseLoadingAnimation = NO;
     self.internalAnimationFactor = 0.7;
     self.loadingAnimationDuration = 1.2;
+    self.pointScale = 1.0;
 }
 
 - (instancetype)initWithStartPoints:(NSArray *)startPoints endPoints:(NSArray *)endPoints;
@@ -213,18 +214,23 @@
 
 - (CGPoint)pointFromObject:(id)object
 {
+    CGPoint point = CGPointZero;
+    
     if ([object isKindOfClass:[NSString class]])
     {
-        return CGPointFromString(object);
+        point = CGPointFromString(object);
     }
     else if ([object isKindOfClass:[NSValue class]])
     {
         NSValue* value = object;
         
-        return [value CGPointValue];
+        point = [value CGPointValue];
     }
     
-    return CGPointZero;
+    point.x *= self.pointScale;
+    point.y *= self.pointScale;
+    
+    return point;
 }
 
 - (void)updateBarItemsWithProgress:(CGFloat)progress

--- a/Class/CBStoreHouseActivityIndicatorView.m
+++ b/Class/CBStoreHouseActivityIndicatorView.m
@@ -99,6 +99,12 @@
     return [self initWithStartPoints:points[startPointKey] endPoints:points[endPointKey]];
 }
 
+- (void)setStartPoints:(NSArray *)startPoints endPoints:(NSArray *)endPoints
+{
+    self.startPoints = startPoints;
+    self.endPoints = endPoints;
+}
+
 - (void)load
 {
     if (self.isLoaded)

--- a/Class/CBStoreHouseActivityIndicatorView.m
+++ b/Class/CBStoreHouseActivityIndicatorView.m
@@ -1,0 +1,355 @@
+//
+//  CBStoreHouseActivityIndicatorView.m
+//  CBStoreHouseRefreshControl
+//
+//  Created by Dal Rupnik on 18/02/15.
+//  Copyright (c) 2015 Suyu Zhang. All rights reserved.
+//
+
+#import "CBStoreHouseRefreshControl.h"
+#import "CBStoreHouseActivityIndicatorView.h"
+
+#import "BarItem.h"
+
+@interface CBStoreHouseActivityIndicatorView ()
+
+@property (nonatomic, copy) NSArray* startPoints;
+@property (nonatomic, copy) NSArray* endPoints;
+
+@property (nonatomic, strong) NSArray *barItems;
+@property (nonatomic, strong) CADisplayLink *displayLink;
+
+@property (nonatomic, assign) CGFloat progress;
+@property (nonatomic, assign) CGFloat internalAnimationFactor;
+
+@property (nonatomic, assign, getter = isLoaded) BOOL loaded;
+
+/*!
+ *  Tells if we are building the bars, or separating
+ */
+@property (nonatomic, assign, getter = isLoadingAnimationIn) BOOL loadingAnimationIn;
+
+@end
+
+@implementation CBStoreHouseActivityIndicatorView
+
+- (void)setAnimating:(BOOL)animating
+{
+    _animating = animating;
+    
+    [self load];
+    
+    if (animating == YES)
+    {
+        if (self.hasLoadingAnimation)
+        {
+            self.loadingAnimationIn = YES;
+            [self startLoadingAnimation];
+        }
+        else
+        {
+            [self updateBarItemsWithProgress:1.0];
+            [self startIndeterminateAnimation];
+        }
+    }
+    else
+    {
+        if (self.hasLoadingAnimation)
+        {
+            self.loadingAnimationIn = NO;
+            [self startLoadingAnimation];
+        }
+    }
+}
+
+- (instancetype)initWithStartPoints:(NSArray *)startPoints endPoints:(NSArray *)endPoints;
+{
+    self = [super initWithFrame:CGRectZero];
+    
+    if (self)
+    {
+        self.color = [UIColor whiteColor];
+        self.lineWidth = 2;
+        self.animationHeight = 80;
+        self.scale = 1;
+        self.horizontalRandomness = 150;
+        self.reverseLoadingAnimation = NO;
+        self.internalAnimationFactor = 0.7;
+        self.loadingAnimationDuration = 1.2;
+        self.startPoints = startPoints;
+        self.endPoints = endPoints;
+    }
+    
+    return self;
+}
+
+- (NSDictionary *)loadPointsFromPlist:(NSString *)plist
+{
+    NSDictionary *rootDictionary = [NSDictionary dictionaryWithContentsOfFile:[[NSBundle mainBundle] pathForResource:plist ofType:@"plist"]];
+    NSArray *startPoints = [rootDictionary objectForKey:startPointKey];
+    NSArray *endPoints = [rootDictionary objectForKey:endPointKey];
+    
+    return @{ startPointKey : startPoints, endPointKey : endPoints };
+}
+
+- (instancetype)initWithPlist:(NSString *)plist
+{
+    NSDictionary* points = [self loadPointsFromPlist:plist];
+    
+    return [self initWithStartPoints:points[startPointKey] endPoints:points[endPointKey]];
+}
+
+- (void)load
+{
+    if (self.isLoaded)
+    {
+        return;
+    }
+    
+    self.loaded = YES;
+    
+    //
+    // Calculate frame according to points max width and height
+    //
+    
+    CGFloat width = 0;
+    CGFloat height = 0;
+    
+    for (int i = 0; i < self.startPoints.count; i++)
+    {
+        CGPoint startPoint = [self pointFromObject:self.startPoints[i]];
+        CGPoint endPoint = [self pointFromObject:self.endPoints[i]];
+        
+        if (startPoint.x > width)
+        {
+            width = startPoint.x;
+        }
+        if (endPoint.x > width)
+        {
+            width = endPoint.x;
+        }
+        if (startPoint.y > height)
+        {
+            height = startPoint.y;
+        }
+        if (endPoint.y > height)
+        {
+            height = endPoint.y;
+        }
+    }
+
+    CGRect bounds = CGRectMake(0, 0, width, height);
+    
+    // Create bar items
+    NSMutableArray *mutableBarItems = [[NSMutableArray alloc] init];
+    
+    for (int i = 0; i < self.startPoints.count; i++)
+    {
+        
+        CGPoint startPoint = [self pointFromObject:self.startPoints[i]];
+        CGPoint endPoint = [self pointFromObject:self.endPoints[i]];
+        
+        BarItem *barItem = [[BarItem alloc] initWithFrame:bounds startPoint:startPoint endPoint:endPoint color:self.color lineWidth:self.lineWidth];
+        barItem.tag = i;
+        barItem.backgroundColor = [UIColor clearColor];
+        barItem.alpha = 0.0;
+        
+        [mutableBarItems addObject:barItem];
+        [self addSubview:barItem];
+        
+        [barItem setHorizontalRandomness:self.horizontalRandomness dropHeight:self.animationHeight];
+    }
+    
+    self.barItems = [mutableBarItems copy];
+
+    for (BarItem *barItem in self.barItems)
+    {
+        [barItem setupWithFrame:bounds];
+    }
+    
+    self.transform = CGAffineTransformMakeScale (self.scale, self.scale);
+}
+
+
+#pragma mark Private Methods
+
+- (CGPoint)pointFromObject:(id)object
+{
+    if ([object isKindOfClass:[NSString class]])
+    {
+        return CGPointFromString(object);
+    }
+    else if ([object isKindOfClass:[NSValue class]])
+    {
+        NSValue* value = object;
+        
+        return [value CGPointValue];
+    }
+    
+    return CGPointZero;
+}
+
+- (void)updateBarItemsWithProgress:(CGFloat)progress
+{
+    for (BarItem *barItem in self.barItems)
+    {
+        NSInteger index = [self.barItems indexOfObject:barItem];
+        CGFloat startPadding = (1 - self.internalAnimationFactor) / self.barItems.count * index;
+        CGFloat endPadding = 1 - self.internalAnimationFactor - startPadding;
+        
+        if (progress == 1 || progress >= 1 - endPadding)
+        {
+            barItem.transform = CGAffineTransformIdentity;
+            barItem.alpha = kbarDarkAlpha;
+        }
+        else if (progress == 0)
+        {
+            [barItem setHorizontalRandomness:self.horizontalRandomness dropHeight:self.animationHeight];
+        }
+        else
+        {
+            CGFloat realProgress;
+            
+            if (progress <= startPadding)
+            {
+                realProgress = 0;
+            }
+            else
+            {
+                realProgress = MIN(1, (progress - startPadding)/self.internalAnimationFactor);
+            }
+            
+            barItem.transform = CGAffineTransformMakeTranslation(barItem.translationX * (1 - realProgress), -self.animationHeight * (1 - realProgress));
+            barItem.transform = CGAffineTransformRotate(barItem.transform, M_PI*(realProgress));
+            barItem.transform = CGAffineTransformScale(barItem.transform, realProgress, realProgress);
+            barItem.alpha = realProgress * kbarDarkAlpha;
+        }
+    }
+}
+
+- (void)startIndeterminateAnimation
+{
+    if (self.progress > 0.0 && self.progress < 1.0)
+    {
+        //NSLog(@"Prog: %f", self.progress);
+        
+        return;
+    }
+    
+    if (self.reverseLoadingAnimation)
+    {
+        int count = (int)self.barItems.count;
+        
+        for (int i = count - 1; i >= 0; i--)
+        {
+            BarItem *barItem = [self.barItems objectAtIndex:i];
+            [self performSelector:@selector(barItemAnimation:) withObject:barItem afterDelay:(self.barItems.count - i - 1) * kloadingTimingOffset inModes:@[NSRunLoopCommonModes]];
+        }
+    }
+    else
+    {
+        for (int i = 0; i < self.barItems.count; i++)
+        {
+            BarItem *barItem = [self.barItems objectAtIndex:i];
+            
+            [self performSelector:@selector(barItemAnimation:) withObject:barItem afterDelay:i * kloadingTimingOffset inModes:@[ NSRunLoopCommonModes ]];
+        }
+    }
+}
+
+- (void)barItemAnimation:(BarItem*)barItem
+{
+    if (self.progress > 0.0 && self.progress < 1.0)
+    {
+        //NSLog(@"Prog: %f", self.progress);
+        
+        return;
+    }
+    
+    barItem.alpha = 1;
+    [barItem.layer removeAllAnimations];
+    [UIView animateWithDuration:kloadingIndividualAnimationTiming animations:^
+    {
+        barItem.alpha = kbarDarkAlpha;
+    } completion:nil];
+    
+    BOOL isLastOne;
+    
+    if (self.reverseLoadingAnimation)
+    {
+        isLastOne = barItem.tag == 0;
+    }
+    else
+    {
+        isLastOne = barItem.tag == self.barItems.count - 1;
+    }
+    
+    if (isLastOne && self.animating)
+    {
+        [self startIndeterminateAnimation];
+    }
+}
+
+- (void)updateLoadingAnimation
+{
+    if (self.progress >= 0 && self.progress <= 1)
+    {
+        NSTimeInterval step = 1.0 / 60.f / self.loadingAnimationDuration;
+        
+        if (self.isLoadingAnimationIn)
+        {
+            self.progress += step;
+        }
+        else
+        {
+            self.progress -= step;
+        }
+        
+        //60.f means this method get called 60 times per second
+        [self updateBarItemsWithProgress:self.progress];
+    }
+}
+
+- (void)startLoadingAnimation
+{
+    //BOOL loadingAnimationIn = self.isLoadingAnimationIn;
+    
+    self.displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(updateLoadingAnimation)];
+    [self.displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+
+    if (self.isLoadingAnimationIn)
+    {
+        self.progress = 0.0;
+    }
+    else
+    {
+        self.progress = 1.0;
+    }
+    
+    for (BarItem *barItem in self.barItems)
+    {
+        [barItem.layer removeAllAnimations];
+        barItem.alpha = kbarDarkAlpha;
+    }
+    
+    [self performSelector:@selector(stopLoadingAnimation) withObject:nil afterDelay:self.loadingAnimationDuration inModes:@[ NSRunLoopCommonModes ]];
+}
+
+- (void)stopLoadingAnimation
+{
+    [self.displayLink invalidate];
+    
+    if (self.isLoadingAnimationIn)
+    {
+        self.progress = 1.0;
+        [self startIndeterminateAnimation];
+    }
+    else
+    {
+        self.progress = 0.0;
+    }
+    
+    [self updateBarItemsWithProgress:self.progress];
+}
+
+@end

--- a/Class/CBStoreHouseActivityIndicatorView.m
+++ b/Class/CBStoreHouseActivityIndicatorView.m
@@ -99,6 +99,14 @@
     return [self initWithStartPoints:points[startPointKey] endPoints:points[endPointKey]];
 }
 
+- (void)setPointsWithPlist:(NSString *)plist
+{
+    NSDictionary* points = [self loadPointsFromPlist:plist];
+    
+    self.startPoints = points[startPointKey];
+    self.endPoints = points[endPointKey];
+}
+
 - (void)setStartPoints:(NSArray *)startPoints endPoints:(NSArray *)endPoints
 {
     self.startPoints = startPoints;

--- a/Class/CBStoreHouseActivityIndicatorView.m
+++ b/Class/CBStoreHouseActivityIndicatorView.m
@@ -62,24 +62,36 @@
     }
 }
 
+- (void)awakeFromNib
+{
+    [super awakeFromNib];
+    
+    [self setup];
+}
+
 - (instancetype)init
 {
     self = [super initWithFrame:CGRectZero];
     
     if (self)
     {
-        self.color = [UIColor whiteColor];
-        self.lineWidth = 2;
-        self.animationHeight = 80;
-        self.scale = 1;
-        self.horizontalRandomness = 150;
-        self.reverseLoadingAnimation = NO;
-        self.internalAnimationFactor = 0.7;
-        self.loadingAnimationDuration = 1.2;
+        [self setup];
     }
     
     return self;
 
+}
+
+- (void)setup
+{
+    self.color = [UIColor whiteColor];
+    self.lineWidth = 2;
+    self.animationHeight = 80;
+    self.scale = 1;
+    self.horizontalRandomness = 150;
+    self.reverseLoadingAnimation = NO;
+    self.internalAnimationFactor = 0.7;
+    self.loadingAnimationDuration = 1.2;
 }
 
 - (instancetype)initWithStartPoints:(NSArray *)startPoints endPoints:(NSArray *)endPoints;

--- a/Class/CBStoreHouseActivityIndicatorView.m
+++ b/Class/CBStoreHouseActivityIndicatorView.m
@@ -92,6 +92,8 @@
     self.reverseLoadingAnimation = NO;
     self.internalAnimationFactor = 0.7;
     self.loadingAnimationDuration = 1.2;
+    self.indeterminateAnimationOffset = 0.1;
+    self.indeterminateAnimationTiming = 0.8;
     self.pointScale = 1.0;
 }
 
@@ -287,7 +289,7 @@
         for (int i = count - 1; i >= 0; i--)
         {
             BarItem *barItem = [self.barItems objectAtIndex:i];
-            [self performSelector:@selector(barItemAnimation:) withObject:barItem afterDelay:(self.barItems.count - i - 1) * kloadingTimingOffset inModes:@[NSRunLoopCommonModes]];
+            [self performSelector:@selector(barItemAnimation:) withObject:barItem afterDelay:(self.barItems.count - i - 1) * self.indeterminateAnimationOffset inModes:@[NSRunLoopCommonModes]];
         }
     }
     else
@@ -296,7 +298,7 @@
         {
             BarItem *barItem = [self.barItems objectAtIndex:i];
             
-            [self performSelector:@selector(barItemAnimation:) withObject:barItem afterDelay:i * kloadingTimingOffset inModes:@[ NSRunLoopCommonModes ]];
+            [self performSelector:@selector(barItemAnimation:) withObject:barItem afterDelay:i * self.indeterminateAnimationOffset inModes:@[ NSRunLoopCommonModes ]];
         }
     }
 }
@@ -305,14 +307,12 @@
 {
     if (self.progress > 0.0 && self.progress < 1.0)
     {
-        //NSLog(@"Prog: %f", self.progress);
-        
         return;
     }
     
     barItem.alpha = 1;
     [barItem.layer removeAllAnimations];
-    [UIView animateWithDuration:kloadingIndividualAnimationTiming animations:^
+    [UIView animateWithDuration:self.indeterminateAnimationTiming animations:^
     {
         barItem.alpha = kbarDarkAlpha;
     } completion:nil];

--- a/Class/CBStoreHouseActivityIndicatorView.m
+++ b/Class/CBStoreHouseActivityIndicatorView.m
@@ -62,7 +62,7 @@
     }
 }
 
-- (instancetype)initWithStartPoints:(NSArray *)startPoints endPoints:(NSArray *)endPoints;
+- (instancetype)init
 {
     self = [super initWithFrame:CGRectZero];
     
@@ -76,6 +76,18 @@
         self.reverseLoadingAnimation = NO;
         self.internalAnimationFactor = 0.7;
         self.loadingAnimationDuration = 1.2;
+    }
+    
+    return self;
+
+}
+
+- (instancetype)initWithStartPoints:(NSArray *)startPoints endPoints:(NSArray *)endPoints;
+{
+    self = [self init];
+    
+    if (self)
+    {
         self.startPoints = startPoints;
         self.endPoints = endPoints;
     }

--- a/Class/CBStoreHouseRefreshControl.h
+++ b/Class/CBStoreHouseRefreshControl.h
@@ -8,6 +8,23 @@
 
 #import <UIKit/UIKit.h>
 
+static const CGFloat kloadingIndividualAnimationTiming = 0.8;
+static const CGFloat kbarDarkAlpha = 0.4;
+static const CGFloat kloadingTimingOffset = 0.1;
+static const CGFloat kdisappearDuration = 1.2;
+static const CGFloat krelativeHeightFactor = 2.f/5.f;
+
+typedef enum {
+    CBStoreHouseRefreshControlStateIdle = 0,
+    CBStoreHouseRefreshControlStateRefreshing = 1,
+    CBStoreHouseRefreshControlStateDisappearing = 2
+} CBStoreHouseRefreshControlState;
+
+extern NSString *const startPointKey;
+extern NSString *const endPointKey;
+extern NSString *const xKey;
+extern NSString *const yKey;
+
 @interface CBStoreHouseRefreshControl : UIView
 
 + (CBStoreHouseRefreshControl*)attachToScrollView:(UIScrollView *)scrollView

--- a/Class/CBStoreHouseRefreshControl.m
+++ b/Class/CBStoreHouseRefreshControl.m
@@ -124,7 +124,6 @@ NSString *const yKey = @"y";
 
 - (void)scrollViewDidScroll
 {
-    if (self.originalTopContentInset == 0) self.originalTopContentInset = self.scrollView.contentInset.top;
     self.center = CGPointMake([UIScreen mainScreen].bounds.size.width/2, self.realContentOffsetY*krelativeHeightFactor);
     if (self.state == CBStoreHouseRefreshControlStateIdle)
         [self updateBarItemsWithProgress:self.animationProgress];

--- a/Class/CBStoreHouseRefreshControl.m
+++ b/Class/CBStoreHouseRefreshControl.m
@@ -9,18 +9,6 @@
 #import "CBStoreHouseRefreshControl.h"
 #import "BarItem.h"
 
-static const CGFloat kloadingIndividualAnimationTiming = 0.8;
-static const CGFloat kbarDarkAlpha = 0.4;
-static const CGFloat kloadingTimingOffset = 0.1;
-static const CGFloat kdisappearDuration = 1.2;
-static const CGFloat krelativeHeightFactor = 2.f/5.f;
-
-typedef enum {
-    CBStoreHouseRefreshControlStateIdle = 0,
-    CBStoreHouseRefreshControlStateRefreshing = 1,
-    CBStoreHouseRefreshControlStateDisappearing = 2
-} CBStoreHouseRefreshControlState;
-
 NSString *const startPointKey = @"startPoints";
 NSString *const endPointKey = @"endPoints";
 NSString *const xKey = @"x";


### PR DESCRIPTION
1. Added ActivityIndicatorView that works in a similar way as refresh control, but can be used as a progress indicator view anywhere.
2. Supports built-in and built-out animations - same as when refresh control is dragged
3. Supports indeterminate animation
4. Fixed a bug in RefreshControl that caused problems with scrollview contentInset property - it always got set to dropHeight, but never returned back.
